### PR TITLE
0.0.0.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,33 +4,45 @@ Site's repo for [Metamod-r](https://github.com/rehlds/metamod-r) project.
 
 ---
 
+## [`0.0.0.8`](https://github.com/rehlds/metamod-r.org/releases/tag/0.0.0.8) - 2024-10-30
+
+### Changed
+- repo moved to official `rehds` organisation
+
+### Fixed
+- fixed changelog
+- fixed readme
+- fixed links on site
+
+**Full Changelog**: [0.0.0.7...0.0.0.8](https://github.com/rehlds/metamod-r.org/compare/0.0.0.7...0.0.0.8)
+
 ## [`0.0.0.7`](https://github.com/rehlds/metamod-r.org/releases/tag/0.0.0.7) - 2018-03-28
 
-## Fixed
+### Fixed
 - UI minor fixes
 
 **Full Changelog**: [0.0.0.6...0.0.0.7](https://github.com/rehlds/metamod-r.org/compare/0.0.0.6...0.0.0.7)
 
 ## [`0.0.0.6`](https://github.com/rehlds/metamod-r.org/releases/tag/0.0.0.6) - 2018-03-28
 
-## Fixed
+### Fixed
 - UI minor fixes
 
 **Full Changelog**: [0.0.0.5...0.0.0.6](https://github.com/rehlds/metamod-r.org/compare/0.0.0.5...0.0.0.6)
 
 ## [`0.0.0.5`](https://github.com/rehlds/metamod-r.org/releases/tag/0.0.0.5) - 2018-03-27
 
-## Added
+### Added
 - easteregg
 
-## Fixed
+### Fixed
 - UI minor fixes
 
 **Full Changelog**: [0.0.0.4...0.0.0.5](https://github.com/rehlds/metamod-r.org/compare/0.0.0.4...0.0.0.5)
 
 ## [`0.0.0.4`](https://github.com/rehlds/metamod-r.org/releases/tag/0.0.0.4) - 2018-03-27
 
-## Fixed
+### Fixed
 - UI minor fixes:
   - PR https://github.com/rehlds/metamod-r.org/pull/8
   - PR https://github.com/rehlds/metamod-r.org/pull/9
@@ -40,14 +52,14 @@ Site's repo for [Metamod-r](https://github.com/rehlds/metamod-r) project.
 
 ## [`0.0.0.3`](https://github.com/rehlds/metamod-r.org/releases/tag/0.0.0.3) - 2018-03-26
 
-## Changed
+### Changed
 - **Migrate to BS4 from BulmaIO by @stamepicmorg** in https://github.com/rehlds/metamod-r.org/pull/7
 
 **Full Changelog**: [0.0.0.2...0.0.0.3](https://github.com/rehlds/metamod-r.org/compare/0.0.0.2...0.0.0.3)
 
 ## [`0.0.0.2`](https://github.com/rehlds/metamod-r.org/releases/tag/0.0.0.2) - 2018-03-23
 
-## Changed
+### Changed
 - **Update bulma.js by @stamepicmorg** in https://github.com/rehlds/metamod-r.org/pull/2
 
 **Full Changelog**: [0.0.0.1...0.0.0.2](https://github.com/rehlds/metamod-r.org/compare/0.0.0.1...0.0.0.2)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # metamod-r.org
 
-Site's repo for [Metamod-r](https://github.com/theAsmodai/metamod-r) project.
+Site's repo for [Metamod-r](https://github.com/rehlds/metamod-r) project.
  
 ### Info
 

--- a/src/index.html
+++ b/src/index.html
@@ -40,7 +40,7 @@
   <!--// Fork Me On GitHub Label  -->
   <div class="fork-me-wrapper">
     <div class="fork-me">
-        <a class="fork-me-link" href="https://github.com/theAsmodai/metamod-r" target="_blank">
+        <a class="fork-me-link" href="https://github.com/rehlds/metamod-r" target="_blank">
             <span class="fork-me-text">Fork Me On GitHub</span>
         </a>
     </div>
@@ -69,13 +69,13 @@
             <a class="nav-link active" href="/">
               <i class="fas fa-home"></i> Home
             </a>
-            <a class="nav-link" href="https://github.com/theAsmodai/metamod-r/releases" target="_blank">
+            <a class="nav-link" href="https://github.com/rehlds/metamod-r/releases" target="_blank">
               <i class="fas fa-download"></i> Releases
             </a>
-            <a class="nav-link" href="https://github.com/theAsmodai/metamod-r/wiki" target="_blank">
+            <a class="nav-link" href="https://github.com/rehlds/metamod-r/wiki" target="_blank">
               <i class="fas fa-book"></i> Documentation
             </a>
-            <a class="nav-link" href="https://github.com/theAsmodai/metamod-r/issues/new" target="_blank">
+            <a class="nav-link" href="https://github.com/rehlds/metamod-r/issues/new" target="_blank">
               <i class="fas fa-exclamation-circle"></i> New issue
             </a>
           </nav>
@@ -123,8 +123,8 @@
       </p>
       
       <p class="lead">Distributed under
-        <a href="https://github.com/theAsmodai/metamod-r/blob/master/LICENSE">
-          <img alt="GitHub license" src="https://img.shields.io/github/license/theAsmodai/metamod-r.svg??longCache=true&style=flat-square">
+        <a href="https://github.com/rehlds/metamod-r/blob/master/LICENSE">
+          <img alt="GitHub license" src="https://img.shields.io/github/license/rehlds/metamod-r.svg??longCache=true&style=flat-square">
         </a>.
       </p>
         
@@ -136,17 +136,17 @@
                   <strong><i class="fas fa-medkit"></i> Project's Health</strong>
                 </h5>
                 <p class="card-text">
-                  <a title="Build status" href="http://teamcity.rehlds.org/viewType.html?buildTypeId=Metamod_Publish&guest=1">
-                    <img alt="Experimental" src="https://img.shields.io/badge/status-experimental-orange.svg?style=flat-square">
+                  <a title="Build status" href="https://github.com/rehlds/metamod-r/actions">
+                    <img alt="Stable" src="https://img.shields.io/badge/status-stable-default.svg?style=flat-square">
                   </a>
-                  <a title="GitHub issues" href="https://github.com/theAsmodai/metamod-r/issues">
-                    <img alt="GitHub issues" src="https://img.shields.io/github/issues/theAsmodai/metamod-r.svg??longCache=true&style=flat-square">
+                  <a title="GitHub issues" href="https://github.com/rehlds/metamod-r/issues">
+                    <img alt="GitHub issues" src="https://img.shields.io/github/issues/rehlds/metamod-r.svg??longCache=true&style=flat-square">
                   </a>
-                  <a title="GitHub forks" href="https://github.com/theAsmodai/metamod-r/network">
-                    <img alt="GitHub forks" src="https://img.shields.io/github/forks/theAsmodai/metamod-r.svg??longCache=true&style=flat-square">
+                  <a title="GitHub forks" href="https://github.com/rehlds/metamod-r/network">
+                    <img alt="GitHub forks" src="https://img.shields.io/github/forks/rehlds/metamod-r.svg??longCache=true&style=flat-square">
                   </a>
-                  <a title="GitHub stars" href="https://github.com/theAsmodai/metamod-r/stargazers">
-                    <img alt="GitHub stars" src="https://img.shields.io/github/stars/theAsmodai/metamod-r.svg??longCache=true&style=flat-square"> 
+                  <a title="GitHub stars" href="https://github.com/rehlds/metamod-r/stargazers">
+                    <img alt="GitHub stars" src="https://img.shields.io/github/stars/rehlds/metamod-r.svg??longCache=true&style=flat-square"> 
                   </a>
                 </p>
               </div>
@@ -157,14 +157,15 @@
               <div class="card-body">
                 <h5 class="card-title"><strong><i class="fas fa-cloud-download-alt"></i> CI Download</strong></h5>
                 <p class="card-text">
-                  <a title="Build status" href="http://teamcity.rehlds.org/viewType.html?buildTypeId=Metamod_Publish&guest=1">
-                    <img alt="Build status" src="https://img.shields.io/teamcity/http/teamcity.rehlds.org/e/Metamod_Publish.svg?style=flat-square&label=TC%20Build">
-                  </aрезы>
-                  <a title="Quick download" href="http://teamcity.rehlds.org/guestAuth/downloadArtifacts.html?buildTypeId=Metamod_Publish&buildId=lastSuccessful">
-                    <img alt="Quick download" src="https://camo.githubusercontent.com/2b15ec2fc402e02b66fde9eab7e896406caeddac/687474703a2f2f7265686c64732e6f72672f76657273696f6e2f6d6574616d6f642d2d722e737667">
+                  <a title="Build status" href="https://github.com/rehlds/metamod-r/actions">
+                    <img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/rehlds/metamod-r/.github%2Fworkflows%2Fbuild.yml?style=flat-square
+">
                   </a>
-                  <a title="GitHub license" href="https://github.com/theAsmodai/metamod-r/blob/master/LICENSE">
-                    <img alt="GitHub license" src="https://img.shields.io/github/license/theAsmodai/metamod-r.svg??longCache=true&style=flat-square">
+                  <a title="Quick download" href="https://github.com/rehlds/metamod-r/releases/latest">
+                    <img alt="Quick download" src="https://img.shields.io/github/downloads/rehlds/metamod-r/latest/total?sort=date&style=flat-square">
+                  </a>
+                  <a title="GitHub license" href="https://github.com/rehlds/metamod-r/blob/master/LICENSE.md">
+                    <img alt="GitHub license" src="https://img.shields.io/github/license/rehlds/metamod-r.svg??longCache=true&style=flat-square">
                   </a>
                 </p>
               </div>
@@ -176,7 +177,7 @@
 
       <footer class="mastfoot mt-auto text-center">
         <div class="inner">
-          <p>Site <a href="https://github.com/EpicMorg/metamod-r.org"><i class="fab fa-github"></i> developed</a> and hosted by <a href="https://ww.epicm.org/"><i class="far fa-hdd"></i> EpicMorg</a>, 2018, <a href="#" data-toggle="modal" data-target="#aboutModal">0.0.0.7</a>.</p>
+          <p>Site <a href="https://github.com/EpicMorg/metamod-r.org"><i class="fab fa-github"></i> developed</a> and hosted by <a href="https://ww.epicm.org/"><i class="far fa-hdd"></i> EpicMorg</a>, 2018-2024, <a href="#" data-toggle="modal" data-target="#aboutModal">0.0.0.8</a>.</p>
         </div>
       </footer>
     </div>
@@ -222,7 +223,7 @@
                   <i class="fab fa-github-alt"></i> <a href="https://github.com/alliedmodders" target="_blank">AlliedModders</a> —  <a href="https://github.com/alliedmodders/metamod-hl1" target="_blank">Metamod-am</a>,
                 </p>
                 <p>
-                  <i class="fab fa-github-alt"></i> <a href="https://github.com/theAsmodai/" target="_blank">theAsmodai</a>, (<a href="http://www.dedicated-server.ru/vbb/" target="_blank">ReHLDS Team</a>) — <a href="https://github.com/theAsmodai/metamod-r" target="_blank">Metamod-r</a>.
+                  <i class="fab fa-github-alt"></i> <a href="https://github.com/rehlds/" target="_blank">rehlds</a>, (<a href="http://www.dedicated-server.ru/vbb/" target="_blank">ReHLDS Team</a>) — <a href="https://github.com/rehlds/metamod-r" target="_blank">Metamod-r</a>.
                 </p>
               </div> 
               <div class="tab-pane fade" id="transtaltionsTab" role="tabpanel" aria-labelledby="transtaltions-tab">


### PR DESCRIPTION
## [`0.0.0.8`](https://github.com/rehlds/metamod-r.org/releases/tag/0.0.0.8) - 2024-10-30

### Changed
- repo moved to official `rehds` organisation

### Fixed
- fixed changelog
- fixed readme
- fixed links on site

**Full Changelog**: [0.0.0.7...0.0.0.8](https://github.com/rehlds/metamod-r.org/compare/0.0.0.7...0.0.0.8)
